### PR TITLE
Add gitignore to template

### DIFF
--- a/src/template/.gitignore
+++ b/src/template/.gitignore
@@ -1,0 +1,5 @@
+.idea
+.vscode
+node_modules
+.DS_Store
+npm-debug.log*

--- a/src/template/.gitignore
+++ b/src/template/.gitignore
@@ -2,4 +2,5 @@
 .vscode
 node_modules
 .DS_Store
+Thumbs.db
 npm-debug.log*


### PR DESCRIPTION
Include a default .gitignore file when using `zem create my-extension` command.