### PR TITLE
Update manifest with compilation hash in dev mode

### DIFF
--- a/src/config/webpack.common.js
+++ b/src/config/webpack.common.js
@@ -1,5 +1,4 @@
 const fs = require("fs");
-const ManifestBuilder = require("../utils/webpack/manifest-builder");
 const SimpleCopyPlugin = require("../utils/webpack/simple-copy-plugin");
 const WatchExtraFilesPlugin = require("../utils/webpack/watch-extra-files");
 const { resolveBuildPath, resolveExtensionPath } = require("../utils/paths");
@@ -52,7 +51,6 @@ module.exports = {
         new SimpleCopyPlugin(copies),
         new WatchExtraFilesPlugin({
             files: [resolveExtensionPath("package.json"), readmePath]
-        }),
-        new ManifestBuilder(extensionPath, bundleName)
+        })
     ]
 };

--- a/src/config/webpack.dev.js
+++ b/src/config/webpack.dev.js
@@ -1,5 +1,13 @@
 const merge = require("webpack-merge");
 const common = require("./webpack.common");
+const ManifestBuilder = require("../utils/webpack/manifest-builder");
+const { resolveExtensionPath } = require("../utils/paths");
+const { bundleName } = require("./constants");
+
+const extensionPath = resolveExtensionPath();
+
+// Build dev manifest
+common.plugins.push(new ManifestBuilder(extensionPath, bundleName, true));
 
 module.exports = merge(common, {
     output: {

--- a/src/config/webpack.prod.js
+++ b/src/config/webpack.prod.js
@@ -1,10 +1,21 @@
 const merge = require("webpack-merge");
 const UglifyJSPlugin = require("uglifyjs-webpack-plugin");
+const ManifestBuilder = require("../utils/webpack/manifest-builder");
 const common = require("./webpack.common");
+const { resolveExtensionPath } = require("../utils/paths");
+const { bundleName } = require("./constants");
 
-common.plugins.push(new UglifyJSPlugin({
-    sourceMap: true
-}));
+const extensionPath = resolveExtensionPath();
+
+common.plugins.push(
+    // Build prod manifest
+    new ManifestBuilder(extensionPath, bundleName),
+
+    // Minify
+    new UglifyJSPlugin({
+        sourceMap: true
+    })
+);
 
 module.exports = merge(common, {
     output: {

--- a/src/utils/webpack/manifest-builder.js
+++ b/src/utils/webpack/manifest-builder.js
@@ -39,9 +39,10 @@ function parseRepository(repoInfo) {
 }
 
 class ManifestBuilder {
-    constructor(extensionPath, bundleName) {
+    constructor(extensionPath, bundleName, developmentMode = false) {
         this.extensionPath = extensionPath;
         this.bundleName = bundleName;
+        this.developmentMode = developmentMode;
     }
 
     apply(compiler) {
@@ -62,11 +63,17 @@ class ManifestBuilder {
             manifest.packageName = pkgInfo.name;
             manifest.name = pkgInfo.zeplin.displayName || pkgInfo.name;
             manifest.description = pkgInfo.description;
-            manifest.version = pkgInfo.version;
             manifest.author = pkgInfo.author;
             manifest.options = pkgInfo.zeplin.options;
             manifest.projectTypes = pkgInfo.zeplin.projectTypes;
             manifest.moduleURL = `./${chunk.files[0]}`;
+
+            if (this.developmentMode) {
+                // Add hash because you're in the middle of dev and you want the "Reload Local Plugins" to detect a change
+                manifest.version = `${pkgInfo.version}-pre.${compilation.hash}`;
+            } else {
+                manifest.version = pkgInfo.version;
+            }
 
             if (pkgInfo.repository) {
                 manifest.repository = parseRepository(pkgInfo.repository);


### PR DESCRIPTION
I want to use `npm start`, (ie: `zem start`) to have a hot-reloading plugin in Zeplin as I build.

`Extensions > Reload Local Extensions` in Zeplin requires that the manifest version change in order for changes to be reflected in app. 

This PR appends the Webpack compilation hash to the end of the manifest version in a semver-compliant way: https://semver.org/#spec-item-9

Closes #14 