### PR TITLE
Add verbose flag to publish command

### DIFF
--- a/src/commands/publish/apiClient.js
+++ b/src/commands/publish/apiClient.js
@@ -6,8 +6,14 @@ const { apiBaseUrl, apiClientId } = require("../../config/constants");
 const { ClientError, ServerError } = require("../../errors");
 
 function createError(response) {
-    const { statusCode, body } = response;
-    const extra = { response: response.toJSON() };
+    const { statusCode, body, headers } = response;
+    const extra = {
+        response: {
+            statusCode,
+            body,
+            headers
+        }
+    };
 
     if (statusCode >= BAD_REQUEST && statusCode < INTERNAL_SERVER_ERROR) {
         const { message, title } = body;

--- a/src/commands/publish/index.js
+++ b/src/commands/publish/index.js
@@ -95,7 +95,7 @@ async function validateReadme({ hasOptions }) {
     }
 }
 
-module.exports = async function (buildPath) {
+module.exports = async function ({ buildPath, verbose }) {
     console.log("Publishing the extension...\n");
 
     pathResolver.init(buildPath);
@@ -140,6 +140,9 @@ module.exports = async function (buildPath) {
     } catch (error) {
         console.log(chalk.red("Publishing extension failed:"));
         console.error(error.message || error);
+        if (verbose && error.extra) {
+            console.error(JSON.stringify(error.extra, null, 2));
+        }
         throw error;
     }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -93,10 +93,11 @@ program
     .command("publish")
     .description(`Publish extension, submitting it for review to be listed on ${chalk.underline("https://extensions.zeplin.io.")}`)
     .option("--path <build-path>", `Path for the extension build to be published`)
-    .action(async command => {
+    .option("--verbose", "Enables verbose logs")
+    .action(async ({ path: buildPath, verbose }) => {
         const publish = require("./commands/publish");
         try {
-            await publish(command.path);
+            await publish({ buildPath, verbose });
         } catch (_) {
             process.exitCode = 1;
         }


### PR DESCRIPTION
## Change description

Add a verbose flag to log error's detail.

Example output:

<img width="623" alt="Screen Shot 2021-11-16 at 12 23 25" src="https://user-images.githubusercontent.com/6606651/141958137-9d7c23d4-7870-45b6-a30d-52f9e73aecc1.png">

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues


## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [x] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
